### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/StephG183/wire/security/code-scanning/1](https://github.com/StephG183/wire/security/code-scanning/1)

To fix this issue, you should explicitly declare a permissions block at the workflow or "job" level specifying the minimum set of permissions required for the workflow's operations. Since the only actions being taken are checking out code and building a Docker image locally, the minimum permissions required are `contents: read`. This should be added either at the top level of the workflow (recommended, as it covers all jobs) or at the job level if you only want this job to be restricted. Specifically, insert a `permissions:` section with `contents: read` directly below the workflow name, before `on:`. This ensures that the GITHUB_TOKEN only has read access to repository contents, mitigating risk if a malicious Action or code is introduced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
